### PR TITLE
custom-diff: simulations

### DIFF
--- a/simapp/helpers/test_helpers.go
+++ b/simapp/helpers/test_helpers.go
@@ -14,7 +14,7 @@ import (
 
 // SimAppChainID hardcoded chainID for simulation
 const (
-	DefaultGenTxGas = 1000000
+	DefaultGenTxGas = 10000000
 	SimAppChainID   = "simulation-app"
 )
 

--- a/x/simulation/mock_tendermint.go
+++ b/x/simulation/mock_tendermint.go
@@ -92,7 +92,7 @@ func updateValidators(
 
 		if update.Power == 0 {
 			if _, ok := current[str]; !ok {
-				tb.Fatalf("tried to delete a nonexistent validator: %s", str)
+				continue
 			}
 
 			event("end_block", "validator_updates", "kicked")

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -345,7 +345,7 @@ func SimulateMsgUndelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper
 		}
 		// if simaccount.PrivKey == nil, delegation address does not exist in accs. Return error
 		if simAccount.PrivKey == nil {
-			return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "account private key is nil"), nil, fmt.Errorf("delegation addr: %s does not exist in simulation accounts", delAddr)
+			return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "account private key is nil"), nil, nil
 		}
 
 		account := ak.GetAccount(ctx, delAddr)
@@ -442,7 +442,7 @@ func SimulateMsgBeginRedelegate(ak types.AccountKeeper, bk types.BankKeeper, k k
 
 		// if simaccount.PrivKey == nil, delegation address does not exist in accs. Return error
 		if simAccount.PrivKey == nil {
-			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgBeginRedelegate, "account private key is nil"), nil, fmt.Errorf("delegation addr: %s does not exist in simulation accounts", delAddr)
+			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgBeginRedelegate, "account private key is nil"), nil, nil
 		}
 
 		account := ak.GetAccount(ctx, delAddr)


### PR DESCRIPTION
- [fix: change up genTxGas for simulation, no err on no priv key sim acc](https://github.com/cosmosquad-labs/cosmos-sdk/pull/3/commits/973c874861d27851e55ebec07bee96d9c8059588)
- [fix: except checking manual deleted validator on mock_tendermint](https://github.com/cosmosquad-labs/cosmos-sdk/pull/3/commits/cd5e78a6b62dd9032ef6b326d6dda66c54878646)

When a module account generated by several other modules among simulation is registered as a validator by CreateValidator Operation of the staking module, an error occurs that cannot be signaled because there is no Private Key, and thus the case is corrected to not be Error. 

In addition, there is a scenario in which an error may occur when validators are removed during Simulation, so it was modified to not be an error at this time.